### PR TITLE
Dockerfile simplifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /projects ${HOME}
 
 ENV GLIBC_VERSION=2.30-r0 \
     ODO_VERSION=v1.0.2 \
-    OC_VERSION=3.11.170 \
+    OC_VERSION=4.3.2 \
     KUBECTL_VERSION=v1.16.3 \
     TKN_VERSION=0.6.0 \
     MAVEN_VERSION=3.6.2 \
@@ -21,8 +21,8 @@ RUN microdnf install -y \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 
 # install oc
-RUN wget -qO- https://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz | tar xvz -C /usr/local/bin && \
-    oc version 
+RUN wget -qO- https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${OC_VERSION}.tar.gz | tar xvz -C /usr/local/bin && \
+    oc version
 
 # install odo
 RUN wget -O /usr/local/bin/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /projects ${HOME}
 
 ENV GLIBC_VERSION=2.30-r0 \
     ODO_VERSION=v1.0.2 \
-    OC_VERSION=4.3.2 \
+    OC_VERSION=3.11.170 \
     KUBECTL_VERSION=v1.16.3 \
     TKN_VERSION=0.6.0 \
     MAVEN_VERSION=3.6.2 \
@@ -21,8 +21,8 @@ RUN microdnf install -y \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 
 # install oc
-RUN wget -qO- https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${OC_VERSION}.tar.gz | tar xvz -C /usr/local/bin && \
-    oc version
+RUN wget -qO- https://mirror.openshift.com/pub/openshift-v3/clients/${OC_VERSION}/linux/oc.tar.gz | tar xvz -C /usr/local/bin && \
+    oc version 
 
 # install odo
 RUN wget -O /usr/local/bin/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN wget http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
 ADD etc/before-start.sh /before-start.sh
 
 # install telepresence
-ENV TELEPRESENCE_VERSION 0.104
+ENV TELEPRESENCE_VERSION=0.104
 RUN git clone https://github.com/telepresenceio/telepresence.git && \
     cd telepresence && PREFIX=/usr/local ./install.sh && \
     echo "Installed Telepresence"
@@ -74,10 +74,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
     echo "Installed Telepresence Dependencies"
 
 # install ike
-RUN wget https://github.com/Maistra/istio-workspace/releases/download/v${IKE_VERSION}/ike_${IKE_VERSION}_Linux_x86_64.tar.gz && \
-    tar -zxvf ike_${IKE_VERSION}_Linux_x86_64.tar.gz && \
-    rm ike_${IKE_VERSION}_Linux_x86_64.tar.gz && \
-    mv ike /usr/local/bin && \
+RUN curl -sL http://git.io/get-ike | bash -s  -- --version=v${IKE_VERSION} --dir=/usr/local/bin && \
+    echo "Installed istio-workspace" && \
     ike version
 
 # Configure openjdk


### PR DESCRIPTION
- simpler (and recommended) way of installing ike binary
- installing ocp client tools v4.3.2 instead of 3.11