### PR TITLE
fix: adds JAVA_TOOL_OPTIONS env var to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV GLIBC_VERSION=2.30-r0 \
     JDK_VERSION=11 \
     YQ_VERSION=2.4.1 \
     ARGOCD_VERSION=v1.3.0 \
-    IKE_VERSION=0.0.3
+    IKE_VERSION=0.0.3 \
+    JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=true"
 
 RUN microdnf install -y \
         bash curl wget tar gzip java-${JDK_VERSION}-openjdk-devel git openssh which httpd python36 && \


### PR DESCRIPTION
In order to discover `mariadb` service from within Quarkus running in the Che Workspace we have to enforce IPv4Stack. Adding it as environment variable will save participants from setting it up on their own.